### PR TITLE
Stop audio output immediately after playback is finished

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.out
 *.user*
 
+build/

--- a/screencloud/src/audionotifier.cpp
+++ b/screencloud/src/audionotifier.cpp
@@ -54,11 +54,6 @@ void AudioNotifier::play(QString file)
     settings.endGroup();
     if(soundNotifications)
     {
-        if(audioFile.isOpen())
-        {
-            audioOutput->stop();
-            audioFile.close();
-        }
 #ifdef Q_OS_MACX
         audioFile.setFileName(QString(qApp->applicationDirPath() + "/../Resources/" + file).toLocal8Bit());
 #else
@@ -97,6 +92,11 @@ void AudioNotifier::play(QString file)
 
 void AudioNotifier::audioStateChanged(QAudio::State state)
 {
+    if(state == QAudio::IdleState)
+    {
+        audioOutput->stop();
+        audioFile.close();
+    }
     if(audioOutput->error() != QAudio::NoError)
     {
         WARNING(tr("Error while playing audio. Code: ") + QString::number(audioOutput->error()));


### PR DESCRIPTION
Audio device is left in an open state even after the playback is finished. This leaves at least pulseaudio on Linux not able to use it for other applications until screencloud is killed. Following messages appear in the syslog when another application tries to play something:

```
лип 04 18:47:47 excieve pulseaudio[2179]: Error opening PCM device front:0: Device or resource busy
лип 04 18:47:47 excieve pulseaudio[2179]: Failed to create sink input: sink is suspended.
```

Stopping the audio output on `IdleState` as [shown](http://qt-project.org/doc/qt-4.8/qaudiooutput.html#details) in the Qt docs fixes this for me.

P.S.
Sorry if this isn't right in some way — I'm not experienced with Qt.
