### PR TITLE
Fix for windows systems with python installed

### DIFF
--- a/screencloud/res/modules/ScreenCloud.py
+++ b/screencloud/res/modules/ScreenCloud.py
@@ -1,3 +1,7 @@
+# fix for windows systems with python installed
+import os, sys
+sys.path = filter(lambda p: p not in (os.environ["PYTHONPATH"] or ""), sys.path)
+
 from PythonQt.QtCore import QSettings
 from PythonQt.QtGui import QDesktopServices
 import os, string, base64


### PR DESCRIPTION
Problem is:
When ScreenCloud.py starts we have this sys.path when running on system with python installed:
[
    u'C:\Users\HasK\AppData\Local\screencloud\ScreenCloud/plugins/dropbox\modules',
    u'C:/Program Files (x86)/ScreenCloud\modules\python-stdlib-native',
    u'C:/Program Files (x86)/ScreenCloud\modules',
    'c:\Python27\Lib',                                           # <-- that is a problem
    'C:\Program Files (x86)\ScreenCloud\libpython2.7.zip',
    'c:\Program Files (x86)\ScreenCloud'
]

In result we have exception: http://goo.gl/s01B2o
Because hashlin.py used from system python installation but native _hashlib module used from ScreenCloud standalone python modules

This is ugly but working.
And slightly better than simple issue in main repo :)
