### PR TITLE
Fix screenshot pixmap being refreshed on each paint event, fixes #106

### DIFF
--- a/screencloud/src/gui-elements/selectionoverlay.cpp
+++ b/screencloud/src/gui-elements/selectionoverlay.cpp
@@ -472,7 +472,8 @@ void SelectionOverlay::moveToScreen(int screenNumber)
         WARNING("Failed to get geometry for screen " + QString::number(currentScreenNumber));
         QMessageBox::warning(NULL, "Failed to get screen geom", "Failed to get geometry for screen " + QString::number(currentScreenNumber));
     }
-    screenshot = QPixmap::grabWindow(QApplication::desktop()->winId(), screenGeom.x(), screenGeom.y(), screenGeom.width(), screenGeom.height());
+    // The pixmap is deep-copied in order to save the screen state at this very moment instead if utilising Qt's implicit data sharing of the original pixmap.
+    screenshot = QPixmap::grabWindow(QApplication::desktop()->winId(), screenGeom.x(), screenGeom.y(), screenGeom.width(), screenGeom.height()).copy();
     if(screenshot.size() != screenGeom.size())
     {
         INFO(tr("Scaling screenshot to fit screenGeom"));


### PR DESCRIPTION
On X11 systems QPixmap's data is implicitly shared so that any external
change to it is propagated each time the pixmap is accessed. This is exactly
the case when SelectionOverlay widget's paint event handler is writing
it to the widget's painter resulting in effects as shown in #106.

In order to fix it the pixmap can be deep-copied at the moment of
grabbing the screen so that it's not connected to the original X11
pixmap anymore.