### PR TITLE
fix: restore multi-monitor screenshot capture in Qt6

### DIFF
--- a/src/screenshooter.cpp
+++ b/src/screenshooter.cpp
@@ -39,6 +39,7 @@ const QImage ScreenShooter::captureFullscreen(bool captureMultipleMonitors)
 {
     QImage allMonitorsScreenshot = ScreenShooter::captureAllMonitors();
 
+    //If capturing only a single monitor, crop the image
     if(!captureMultipleMonitors)
     {
         QScreen* screen = QGuiApplication::screenAt(QCursor::pos());
@@ -47,6 +48,7 @@ const QImage ScreenShooter::captureFullscreen(bool captureMultipleMonitors)
         return allMonitorsScreenshot.copy(screen->geometry().translated(-virt.topLeft()));
     }
 
+    //Otherwise return the image as is
     return allMonitorsScreenshot;
 }
 
@@ -189,7 +191,8 @@ const QImage ScreenShooter::captureAllMonitors()
         }
     }
 #endif
-    // Qt6: grabWindow(0) captures only "this screen", not the full virtual desktop.
+    //If we are on Win/Mac, or not running on Wayland, use the Qt API to take a screenshot
+    // Grab each screen individually and composite them into one image.
     // Grab each screen individually and composite them into one image.
     INFO(QObject::tr("Capturing the screen using the Qt API"));
     QRect virt = virtualDesktopRect();

--- a/src/screenshooter.cpp
+++ b/src/screenshooter.cpp
@@ -193,7 +193,6 @@ const QImage ScreenShooter::captureAllMonitors()
 #endif
     //If we are on Win/Mac, or not running on Wayland, use the Qt API to take a screenshot
     // Grab each screen individually and composite them into one image.
-    // Grab each screen individually and composite them into one image.
     INFO(QObject::tr("Capturing the screen using the Qt API"));
     QRect virt = virtualDesktopRect();
     QImage result(virt.size(), QImage::Format_RGB32);

--- a/src/screenshooter.cpp
+++ b/src/screenshooter.cpp
@@ -27,31 +27,34 @@
 #include <utils/freedesktopdbusresponse.h>
 #endif
 
+static QRect virtualDesktopRect()
+{
+    QRect r;
+    for (QScreen *s : QGuiApplication::screens())
+        r = r.united(s->geometry());
+    return r;
+}
+
 const QImage ScreenShooter::captureFullscreen(bool captureMultipleMonitors)
 {
     QImage allMonitorsScreenshot = ScreenShooter::captureAllMonitors();
 
-    //If capturing only a single monitor, crop the image
     if(!captureMultipleMonitors)
     {
-        #if QT_VERSION >= QT_VERSION_CHECK(5,10,0)
-            QScreen* screen = QGuiApplication::screenAt(QCursor::pos());
-        #else
-            int screenNumber = QApplication::desktop()->screenNumber(QCursor::pos());
-            QScreen* screen = QApplication::screens().at(screenNumber);
-        #endif
-            return allMonitorsScreenshot.copy(screen->geometry());
+        QScreen* screen = QGuiApplication::screenAt(QCursor::pos());
+        if (!screen) screen = QApplication::primaryScreen();
+        QRect virt = virtualDesktopRect();
+        return allMonitorsScreenshot.copy(screen->geometry().translated(-virt.topLeft()));
     }
 
-    //Otherwise return the image as is
     return allMonitorsScreenshot;
 }
 
 const QImage ScreenShooter::captureSelection(const QRect &area)
 {
+    QRect virt = virtualDesktopRect();
     QImage allMonitorsScreenshot = ScreenShooter::captureAllMonitors();
-    QImage areaScreenshot = allMonitorsScreenshot.copy(area);
-    return areaScreenshot;
+    return allMonitorsScreenshot.copy(area.translated(-virt.topLeft()));
 }
 
 const QImage ScreenShooter::captureWindow(WId windowID, bool captureWindowBorders)
@@ -186,11 +189,20 @@ const QImage ScreenShooter::captureAllMonitors()
         }
     }
 #endif
-    //If we are on Win/Mac, or not running on Wayland, use the Qt API to take a screenshot
+    // Qt6: grabWindow(0) captures only "this screen", not the full virtual desktop.
+    // Grab each screen individually and composite them into one image.
     INFO(QObject::tr("Capturing the screen using the Qt API"));
-    QScreen* screen = QApplication::primaryScreen();
-    QRect screenGeometry = screen->virtualGeometry();
-    QPixmap pixmap = screen->grabWindow(0, screenGeometry.x(), screenGeometry.y(), screenGeometry.width(), screenGeometry.height());
-
-    return pixmap.toImage();
+    QRect virt = virtualDesktopRect();
+    QImage result(virt.size(), QImage::Format_RGB32);
+    result.fill(Qt::black);
+    QPainter painter(&result);
+    for (QScreen *s : QGuiApplication::screens()) {
+        QImage screenImg = s->grabWindow(0).toImage();
+        QRect target = s->geometry().translated(-virt.topLeft());
+        if (screenImg.size() != target.size())
+            screenImg = screenImg.scaled(target.size(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+        painter.drawImage(target.topLeft(), screenImg);
+    }
+    painter.end();
+    return result;
 }

--- a/src/screenshooter.h
+++ b/src/screenshooter.h
@@ -17,9 +17,11 @@
 #include <QObject>
 #include <QPixmap>
 #include <QApplication>
+#include <QGuiApplication>
 #include <QSettings>
 #include <QScreen>
 #include <QImage>
+#include <QPainter>
 
 class ScreenShooter
 {


### PR DESCRIPTION
## Problem
  
  After the Qt6 migration, screenshot capture on multi-monitor setups is broken.
  `captureAllMonitors()`, `captureFullscreen()`, and `captureSelection()` all produce
  incorrect results — the image shows only the primary screen content regardless of
  which monitor the cursor is on.
  
  **Root cause:** Qt6's `QScreen::grabWindow(0)` captures only the screen it belongs to,
  whereas Qt5's `QApplication::desktop()->winId()` referred to the X11 root window which
  spans the full virtual desktop. The single-line change in the Qt6 migration
  (`grabWindow(desktopWinId, ...)` → `grabWindow(0, ...)`) silently broke this behavior.

  Additionally, `QScreen::geometry()` returns Qt logical coordinates which can be
  negative (e.g. a monitor to the left of the primary has negative X). The old code
  passed these coordinates directly to `QImage::copy()` which uses pixel coordinates —
  a mismatch that causes wrong crops.

  ## Fix
  
  - `captureAllMonitors()`: iterate all `QGuiApplication::screens()`, grab each one
    with `s->grabWindow(0)`, and composite onto a canvas sized to the full virtual desktop
  - `captureFullscreen()` and `captureSelection()`: translate screen geometry relative
    to the virtual desktop origin before cropping

  Tested on a two-monitor setup (primary 2560×1440 + secondary 1920×1200) on X11/Qt6.